### PR TITLE
Fixed issue where nav menu would still be hidden after resizing above 800px width

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -1,10 +1,6 @@
 /* Header */
 .header {
-    background: linear-gradient(
-        to bottom left,
-        var(--colour-primary),
-        var(--colour-secondary)
-    );
+    background: linear-gradient(to bottom left, var(--colour-primary), var(--colour-secondary));
     color: var(--colour-text-light);
     padding-top: var(--spacing-xl);
     padding-bottom: var(--spacing-xxl);
@@ -55,9 +51,16 @@
 .header__nav {
     border-bottom: 1px solid var(--colour-text-light);
     padding-bottom: 5px;
-    display: flex;
     gap: var(--spacing-l);
     margin-top: var(--spacing-l);
+}
+
+.header__nav--visible {
+    display: flex;
+}
+
+.header__nav--hidden {
+    display: none;
 }
 
 .header__menu-button {
@@ -80,7 +83,6 @@
     }
 
     .header__nav {
-        display: none;
         width: fit-content;
         grid-row: 2;
         grid-column: 1 / span 2;
@@ -88,12 +90,6 @@
         gap: var(--spacing-l);
         margin-top: var(--spacing-l);
         justify-self: center;
-    }
-}
-
-@media (min-width: 800px) {
-    .header__nav {
-        margin-top: 0;
     }
 }
 

--- a/js/menu.js
+++ b/js/menu.js
@@ -8,20 +8,42 @@ class Menu {
 
     init() {
         this.buttonImage.addEventListener('click', (e) => this.toggleMenu())
+        window.addEventListener('resize', (e) => {
+            if (window.innerWidth > 800) {
+                console.log('Window width over 800px - showing nav')
+                this.openMenu()
+            }
+        })
+
+        if (window.innerWidth > 800) {
+            this.nav.classList.add('header__nav--visible')
+        } else {
+            this.nav.classList.add('header__nav--hidden')
+        }
     }
 
     toggleMenu() {
         if (window.innerWidth <= 800) {
-            if (this.nav.style.display === 'none') {
-                console.log('Opening menu')
-                this.buttonText.textContent = 'CLOSE'
-                this.nav.style.display = 'flex'
+            if (this.nav.classList.contains('header__nav--hidden')) {
+                this.openMenu()
             } else {
-                console.log('Closing menu')
-                this.buttonText.textContent = 'MENU'
-                this.nav.style.display = 'none'
+                this.closeMenu()
             }
         }
+    }
+
+    openMenu() {
+        console.log('Opening menu')
+        this.buttonText.textContent = 'CLOSE'
+        this.nav.classList.add('header__nav--visible')
+        this.nav.classList.remove('header__nav--hidden')
+    }
+
+    closeMenu() {
+        console.log('Closing menu')
+        this.buttonText.textContent = 'MENU'
+        this.nav.classList.add('header__nav--hidden')
+        this.nav.classList.remove('header__nav--visible')
     }
 }
 


### PR DESCRIPTION
Fixed an issue where the nav menu would stay hidden when the screen was resized above 800px width with the hamburger menu closed.

Also changes the way menu.js shows/hides the nav menu:
- Previous method: directly changing the HTML element style attribute
- New method: using a visible and hidden modifier class (header__nav--visible and header__nav--hidden)